### PR TITLE
Added support for all separator founded in the mask 

### DIFF
--- a/app/src/main/java/br/com/jansenfelipe/androidmask/MaskEditTextChangedListener.java
+++ b/app/src/main/java/br/com/jansenfelipe/androidmask/MaskEditTextChangedListener.java
@@ -3,6 +3,8 @@ package br.com.jansenfelipe.androidmask;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.EditText;
+import java.util.HashSet;
+import java.util.Set;
 
 public class MaskEditTextChangedListener implements TextWatcher{
 
@@ -10,18 +12,27 @@ public class MaskEditTextChangedListener implements TextWatcher{
 
     private String mMask;
     private EditText mEditText;
-
+    private Set<String> symbolMask = new HashSet<String>();
     private boolean isUpdating;
     private String old = "";
 
     public MaskEditTextChangedListener(String mask, EditText editText) {
         mMask = mask;
         mEditText = editText;
+        initSymbolMask();
+    }
+
+    private void initSymbolMask(){
+        for (int i=0; i < mMask.length(); i++){
+            char ch = mMask.charAt(i);
+            if (ch != '#')
+                symbolMask.add(String.valueOf(ch));
+        }
     }
 
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
-        String str = Utils.unmask(s.toString());
+        String str = Utils.unmask(s.toString(), symbolMask);
         String mascara = "";
 
         if (isUpdating) {

--- a/app/src/main/java/br/com/jansenfelipe/androidmask/Utils.java
+++ b/app/src/main/java/br/com/jansenfelipe/androidmask/Utils.java
@@ -1,12 +1,16 @@
 package br.com.jansenfelipe.androidmask;
 
 
+import java.util.Set;
+
 public abstract class Utils {
 
-    public static String unmask(String s) {
-        return s.replaceAll("[.]", "").replaceAll("[-]", "")
-                .replaceAll("[/]", "").replaceAll("[(]", "")
-                .replaceAll("[)]", "");
+    public static String unmask(String s, Set<String> replaceSymbols) {
+
+        for (String symbol : replaceSymbols)
+            s = s.replaceAll("["+symbol+"]","");
+
+        return s;
     }
 
     public static String mask(String format, String text){


### PR DESCRIPTION
With this changes you can enter in the mask whatever symbol you want, not only . - ( )

I made this because I needed to mask an hour like this ##:##
